### PR TITLE
layer.conf: remove LAYERSERIES_COMPAT

### DIFF
--- a/meta-validation/conf/layer.conf
+++ b/meta-validation/conf/layer.conf
@@ -8,4 +8,3 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "validation"
 BBFILE_PATTERN_validation = "^${LAYERDIR}/"
 BBFILE_PRIORITY_validation = "6"
-LAYERSERIES_COMPAT_validation = "rocko"


### PR DESCRIPTION
meta-validation does not require any particular version of Yocto.
Remove LAYERSERIES_COMPAT to remove the Yocto version checking.